### PR TITLE
Improve news feed layout

### DIFF
--- a/pandemia-fi/src/pages/uutishuone/components/news-feed-item/news-feed-item.tsx
+++ b/pandemia-fi/src/pages/uutishuone/components/news-feed-item/news-feed-item.tsx
@@ -19,8 +19,8 @@ const NewsFeedItem: React.FunctionComponent<NewsFeedItemProps> = ({
       rel="noreferrer noopener"
     >
       <Box
-        p={2}
         sx={{
+          p: 2,
           borderBottom: "1pt dashed #000",
           backgroundColor: "#fff",
         }}
@@ -37,7 +37,6 @@ const NewsFeedItem: React.FunctionComponent<NewsFeedItemProps> = ({
         <Text
           className="NewsFeedItem__description"
           fontSize={[1, 1, 2]}
-          // color="gray"
           sx={{
             lineHeight: "18px",
             color: "#1e4454",
@@ -45,7 +44,14 @@ const NewsFeedItem: React.FunctionComponent<NewsFeedItemProps> = ({
         >
           {feedItem.description}
         </Text>
-        <Text className="NewsFeedItem__date" fontSize={[1, 1, 2]} color="gray">
+        <Text
+          className="NewsFeedItem__date"
+          fontSize={[1, 1, 2]}
+          sx={{
+            color: "gray",
+            textAlign: "right",
+          }}
+        >
           {feedItem.dateTime.format("D.M.YYYY HH:mm:ss")}
         </Text>
       </Box>

--- a/pandemia-fi/src/pages/uutishuone/components/news-feed-item/news-feed-item.tsx
+++ b/pandemia-fi/src/pages/uutishuone/components/news-feed-item/news-feed-item.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Link, Box, Text, Heading } from "rebass";
+import { Flex, Box, Text, Heading, Link } from "rebass";
 
 interface NewsFeedItemProps {
   feedItem: FeedItem;
@@ -25,35 +25,41 @@ const NewsFeedItem: React.FunctionComponent<NewsFeedItemProps> = ({
           backgroundColor: "#fff",
         }}
       >
-        <Heading
-          className="NewsFeedItem__title"
-          fontSize={[2, 2, 2]}
-          sx={{
-            color: "#1e4454",
-          }}
-        >
-          {feedItem.title}
-        </Heading>
-        <Text
-          className="NewsFeedItem__description"
-          fontSize={[1, 1, 2]}
-          sx={{
-            lineHeight: "18px",
-            color: "#1e4454",
-          }}
-        >
-          {feedItem.description}
-        </Text>
-        <Text
-          className="NewsFeedItem__date"
-          fontSize={[1, 1, 2]}
-          sx={{
-            color: "gray",
-            textAlign: "right",
-          }}
-        >
-          {feedItem.dateTime.format("D.M.YYYY HH:mm:ss")}
-        </Text>
+        <Flex>
+          <Box>
+            <Heading
+              className="NewsFeedItem__title"
+              fontSize={[2, 2, 2]}
+              sx={{
+                color: "#1e4454",
+              }}
+            >
+              {feedItem.title}
+            </Heading>
+            <Text
+              className="NewsFeedItem__description"
+              fontSize={[1, 1, 2]}
+              sx={{
+                lineHeight: "18px",
+                color: "#1e4454",
+              }}
+            >
+              {feedItem.description}
+            </Text>
+          </Box>
+          <Box>
+            <Text
+              className="NewsFeedItem__date"
+              fontSize={[1, 1, 2]}
+              sx={{
+                color: "gray",
+                textAlign: "right",
+              }}
+            >
+              {feedItem.dateTime.format("D.M.YYYY HH:mm:ss")}
+            </Text>
+          </Box>
+        </Flex>
       </Box>
     </Link>
   );

--- a/pandemia-fi/src/pages/uutishuone/components/news-feed-item/news-feed-item.tsx
+++ b/pandemia-fi/src/pages/uutishuone/components/news-feed-item/news-feed-item.tsx
@@ -18,49 +18,54 @@ const NewsFeedItem: React.FunctionComponent<NewsFeedItemProps> = ({
       target="_blank"
       rel="noreferrer noopener"
     >
-      <Box
+      <Flex
         sx={{
           p: 2,
           borderBottom: "1pt dashed #000",
           backgroundColor: "#fff",
+          maxWidth: "100%",
         }}
       >
-        <Flex>
-          <Box>
-            <Heading
-              className="NewsFeedItem__title"
-              fontSize={[2, 2, 2]}
-              sx={{
-                color: "#1e4454",
-              }}
-            >
-              {feedItem.title}
-            </Heading>
-            <Text
-              className="NewsFeedItem__description"
-              fontSize={[1, 1, 2]}
-              sx={{
-                lineHeight: "18px",
-                color: "#1e4454",
-              }}
-            >
-              {feedItem.description}
-            </Text>
-          </Box>
-          <Box>
-            <Text
-              className="NewsFeedItem__date"
-              fontSize={[1, 1, 2]}
-              sx={{
-                color: "gray",
-                textAlign: "right",
-              }}
-            >
-              {feedItem.dateTime.format("D.M.YYYY HH:mm:ss")}
-            </Text>
-          </Box>
-        </Flex>
-      </Box>
+        <Box>
+          <Heading
+            className="NewsFeedItem__title"
+            fontSize={[2, 2, 2]}
+            sx={{
+              color: "#1e4454",
+            }}
+          >
+            {feedItem.title}
+          </Heading>
+          <Text
+            className="NewsFeedItem__description"
+            fontSize={[1, 1, 2]}
+            sx={{
+              lineHeight: "18px",
+              color: "#1e4454",
+            }}
+          >
+            {feedItem.description}
+          </Text>
+        </Box>
+        <Box
+          sx={{
+            px: 1,
+            backgroundColor: "#fff",
+            minWidth: "10ex",
+          }}
+        >
+          <Text
+            className="NewsFeedItem__date"
+            fontSize={[1, 1, 2]}
+            sx={{
+              color: "#3A6579",
+              textAlign: "right",
+            }}
+          >
+            {feedItem.dateTime.format("D.M.YYYY HH:mm:ss")}
+          </Text>
+        </Box>
+      </Flex>
     </Link>
   );
 };

--- a/pandemia-fi/src/pages/uutishuone/uutishuone.tsx
+++ b/pandemia-fi/src/pages/uutishuone/uutishuone.tsx
@@ -124,6 +124,7 @@ const Uutishuone: React.FunctionComponent = () => {
         <Card
           sx={{
             p: 0,
+            maxWidth: "100%",
           }}
         >
           <Heading

--- a/pandemia-fi/src/pages/uutishuone/uutishuone.tsx
+++ b/pandemia-fi/src/pages/uutishuone/uutishuone.tsx
@@ -111,9 +111,26 @@ const Uutishuone: React.FunctionComponent = () => {
           ))}
         </Card>
       </Box>
-      <Box p={0} width={["100%", "100%", "70%"]}>
-        <Card p={3}>
-          <Heading>Uutishuone</Heading>
+      <Box
+        width={["100%", "100%", "70%"]}
+        sx={{
+          p: 0,
+        }}
+      >
+        <Card
+          sx={{
+            p: 0,
+          }}
+        >
+          <Heading
+            sx={{
+              fontSize: 4,
+              p: 2,
+              pb: 1,
+            }}
+          >
+            Uutishuone
+          </Heading>
           {isLoading && <SpinnerBlock />}
           {!isLoading && renderContent()}
         </Card>

--- a/pandemia-fi/src/pages/uutishuone/uutishuone.tsx
+++ b/pandemia-fi/src/pages/uutishuone/uutishuone.tsx
@@ -60,7 +60,11 @@ const Uutishuone: React.FunctionComponent = () => {
         <NewsFeedItem feedItem={feedItem} key={`${feedItem.feedId}-${index}`} />
       ))}
       <Flex justifyContent="center">
-        <Box>
+        <Box
+          sx={{
+            pt: 3,
+          }}
+        >
           <Button
             variant="outline"
             onClick={() => setPageNumber(pageNumber + 1)}


### PR DESCRIPTION
## What is the goal of this PR?

- Improve news feed layout
- Improve code quality

## How does this PR achieve the goal?

### fix: improve news feed layout
- Improve news feed layout
- Remove unneeded padding to add more space for mobile layouts
- Improve code consistency

### fix: improve NewsFeedItem code structure
- Improve NewsFeedItem code structure
- Improve code consistency
 - Move more styles to `sx={{ }}` style blocks

### fix: add padding to the show more items button
- Add padding top to the show more news feed items button
  - "Näytä lisää"

### fix: split news feed items to a flexbox layout
- Split news feed items to a flexbox layout
- Improve readability of the content structure
- Improve code readability

### fix: improve NewsFeedItem layout & code structure

- Improve NewsFeedItem layout & code structure
- Convert the code to use Flex component from Rebass
- Add minimum width to the date & time area
- Change text color of the `NewsFeedItem__date` element

### fix: additional safeguards for Uutishuone layout
- Additional safeguards for Uutishuone layout
- Try to prevent potential element width overflow issues

## Is it a visual change?

### Mobile layout for the news feed

![2020-04-10-2024-pandemia-fi-localhost-uutishuone-iPhone-6_7_8](https://user-images.githubusercontent.com/135053/79011953-dd240b00-7b6d-11ea-8533-57e4e56a72fa.png)
